### PR TITLE
Add Docker Compose installation step

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
+      - name: Install Docker Compose
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y docker-compose
+
       - name: Run Docker tests
         run: |
           cd test/docker


### PR DESCRIPTION
## Summary
- install Docker Compose in integration tests job

## Testing
- `sudo apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685643ccb1b08320ba71f3019c9f1113