### PR TITLE
Fix shellcheck path in entrypoint

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,6 +10,7 @@ fi
 
 export BRANCHES_CLEANER_HOME
 
+# shellcheck source=src/main.sh
 source "$BRANCHES_CLEANER_HOME/src/main.sh"
 
 for a in "${@}"; do


### PR DESCRIPTION
## Summary
- annotate `source` directive for shellcheck

## Testing
- `bash test/inactive_branches_test.sh`
- `bats test/bats` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68564a8c9cb883208ef3779ac50e7c53